### PR TITLE
feat(docs): add Microsoft Clarity with consent-gated analytics

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -607,6 +607,50 @@
   transform: translateY(0);
 }
 
+/* Consent banner secondary action should match primary button shape/weight
+   while remaining visually secondary with clear contrast. */
+:root,
+[data-md-color-scheme="default"] {
+  --scale-consent-secondary-fg: var(--scale-dark-violet);
+  --scale-consent-secondary-border: rgba(43, 29, 79, 0.55);
+  --scale-consent-secondary-bg: rgba(43, 29, 79, 0.08);
+  --scale-consent-secondary-bg-hover: rgba(43, 29, 79, 0.14);
+}
+
+[data-md-color-scheme="slate"] {
+  --scale-consent-secondary-fg: #d3fff9;
+  --scale-consent-secondary-border: rgba(129, 244, 225, 0.65);
+  --scale-consent-secondary-bg: rgba(129, 244, 225, 0.12);
+  --scale-consent-secondary-bg-hover: rgba(129, 244, 225, 0.2);
+}
+
+.md-consent__controls .md-button {
+  border-radius: var(--scale-radius);
+  font-weight: 600;
+}
+
+.md-consent__controls label.md-button[for="__settings"] {
+  background-color: var(--scale-consent-secondary-bg);
+  border: 0.1rem solid var(--scale-consent-secondary-border);
+  color: var(--scale-consent-secondary-fg);
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease,
+    transform 0.1s ease;
+}
+
+.md-consent__controls label.md-button[for="__settings"]:hover,
+.md-consent__controls label.md-button[for="__settings"]:focus-visible {
+  background-color: var(--scale-consent-secondary-bg-hover);
+  border-color: var(--scale-consent-secondary-fg);
+  color: var(--scale-consent-secondary-fg);
+  transform: translateY(-1px);
+}
+
+.md-consent__controls label.md-button[for="__settings"]:active {
+  transform: translateY(0);
+}
+
 /* --------------------------------------------------------------------------
    10. Header
    -------------------------------------------------------------------------- */

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,19 @@ extra:
     provider: mike
     alias: true
     default: stable
+  consent:
+    title: Cookie consent
+    description: >-
+      We use analytics cookies from Google Analytics and Microsoft Clarity to
+      understand documentation usage and improve the experience.
+    actions:
+      - accept
+      - reject
+      - manage
+    cookies:
+      analytics:
+        name: Analytics (Google Analytics and Microsoft Clarity)
+        checked: false
   analytics:
     provider: google
     property: G-FQW9W5SC5P

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,15 +63,15 @@ extra:
   consent:
     title: Cookie consent
     description: >-
-      We use analytics cookies from Google Analytics and Microsoft Clarity to
-      understand documentation usage and improve the experience.
+      We use analytics cookies from Google Analytics, Microsoft Clarity, and
+      reb2b to understand documentation usage and improve the experience.
     actions:
       - accept
       - reject
       - manage
     cookies:
       analytics:
-        name: Analytics (Google Analytics and Microsoft Clarity)
+        name: Analytics (Google Analytics, Microsoft Clarity, and reb2b)
         checked: false
   analytics:
     provider: google

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -3,4 +3,28 @@
   href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Lato:wght@700;800;900&family=JetBrains+Mono:wght@400;500&display=swap"
   rel="stylesheet"
 />
+<script id="__clarity">
+  function __md_clarity() {
+    if (window.__md_clarity_initialized) return;
+    window.__md_clarity_initialized = true;
+    (function (c, l, a, r, i, t, y) {
+      c[a] =
+        c[a] ||
+        function () {
+          (c[a].q = c[a].q || []).push(arguments);
+        };
+      t = l.createElement(r);
+      t.async = 1;
+      t.src = "https://www.clarity.ms/tag/" + i;
+      y = l.getElementsByTagName(r)[0];
+      y.parentNode.insertBefore(t, y);
+    })(window, document, "clarity", "script", "vpkkzb2m3e");
+  }
+  {% if config.extra.consent %}
+  var consent = __md_get("__consent");
+  consent && consent.analytics && __md_clarity();
+  {% else %}
+  __md_clarity();
+  {% endif %}
+</script>
 {% endblock %}

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -27,4 +27,41 @@
   __md_clarity();
   {% endif %}
 </script>
+<script id="__reb2b">
+  function __md_reb2b() {
+    var reb2b = (window.reb2b = window.reb2b || []);
+    if (reb2b.invoked) return;
+    reb2b.invoked = true;
+    reb2b.methods = ["identify", "collect"];
+    reb2b.factory = function (method) {
+      return function () {
+        var args = Array.prototype.slice.call(arguments);
+        args.unshift(method);
+        reb2b.push(args);
+        return reb2b;
+      };
+    };
+    for (var i = 0; i < reb2b.methods.length; i++) {
+      var key = reb2b.methods[i];
+      reb2b[key] = reb2b.factory(key);
+    }
+    reb2b.load = function (key) {
+      var script = document.createElement("script");
+      script.type = "text/javascript";
+      script.async = true;
+      script.src =
+        "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";
+      var first = document.getElementsByTagName("script")[0];
+      first.parentNode.insertBefore(script, first);
+    };
+    reb2b.SNIPPET_VERSION = "1.0.1";
+    reb2b.load("4N210H5G9Y6Z");
+  }
+  {% if config.extra.consent %}
+  var consent = __md_get("__consent");
+  consent && consent.analytics && __md_reb2b();
+  {% else %}
+  __md_reb2b();
+  {% endif %}
+</script>
 {% endblock %}

--- a/overrides/partials/javascripts/consent.html
+++ b/overrides/partials/javascripts/consent.html
@@ -1,0 +1,74 @@
+{#-
+  Override Material consent behavior:
+  - Accept defaults to accepting all cookies unless user opens Manage
+  - Reject is persisted explicitly
+  - Legacy empty-object consent is migrated to "unset" to re-prompt users
+-#}
+<script>
+  (function () {
+    var consent = __md_get("__consent");
+    if (
+      consent &&
+      "object" === typeof consent &&
+      !Array.isArray(consent) &&
+      0 === Object.keys(consent).length
+    ) {
+      localStorage.removeItem(__md_scope.pathname + ".__consent");
+      consent = null;
+    }
+
+    var form = document.forms.consent;
+    if (!form) return;
+
+    if (consent) {
+      for (var input of form.elements) {
+        if (input.name) input.checked = !!consent[input.name];
+      }
+    } else if ("file:" !== location.protocol) {
+      setTimeout(function () {
+        var banner = document.querySelector("[data-md-component=consent]");
+        if (banner) banner.hidden = false;
+      }, 250);
+    }
+
+    form.addEventListener(
+      "submit",
+      function (e) {
+        e.preventDefault();
+
+        var settings = document.getElementById("__settings");
+        var managing = settings && settings.checked;
+        if (!managing) {
+          for (var input of form.elements) {
+            if (input.name) input.checked = true;
+          }
+        }
+
+        var accepted = Object.fromEntries(
+          Array.from(new FormData(form).keys()).map(function (name) {
+            return [name, true];
+          })
+        );
+        accepted.__decision = "accepted";
+        __md_set("__consent", accepted);
+        location.hash = "";
+        location.reload();
+      },
+      false
+    );
+
+    form.addEventListener(
+      "reset",
+      function (e) {
+        e.preventDefault();
+        for (var input of form.elements) {
+          if (input.name) input.checked = false;
+        }
+        __md_set("__consent", { __decision: "rejected" });
+        location.hash = "";
+        location.reload();
+      },
+      false
+    );
+  })();
+</script>


### PR DESCRIPTION
## Summary
- add Microsoft Clarity tracking snippet to the MkDocs override template
- gate Clarity initialization behind analytics consent when consent is configured
- enable MkDocs Material cookie consent banner for analytics cookies (Google Analytics + Microsoft Clarity)

## Privacy/Cookies notes
- the docs site footer points to an external privacy statement: https://spectralcompute.com/privacy-policy
- this repository does not contain an in-repo privacy or cookie policy page to update
- please ensure the external policy is updated to mention Microsoft Clarity usage

## Testing
- uv run mkdocs build --strict