### PR TITLE
Unify how the docs link to Discord, and move contact details to .com

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -50,7 +50,7 @@ can be found [here](https://github.com/spectral-compute/scale-validation?tab=rea
 We also offer some [toy programs](./examples/README.md) to illustrate the process in a very simple
 environment.
 
-Join our [Discord](https://discord.com/invite/KNpgGbTc38) to let us know what projects are missing, or support our mission by contributing yourself.
+Join our [Discord](./contact/join-our-discord.md) to let us know what projects are missing, or support our mission by contributing yourself.
 
 ## Which GPUs are supported?
 
@@ -142,5 +142,5 @@ SCALE is a work in progress. If something gets in your way, please contact us.
 
 There are multiple ways to get in touch with us:
 
- - Join our [Discord](https://discord.gg/KNpgGbTc38)
+ - Join our [Discord](./contact/join-our-discord.md)
  - Send us an e-mail at [hello@spectralcompute.co.uk](mailto:hello@spectralcompute.co.uk)

--- a/docs/README.md
+++ b/docs/README.md
@@ -143,4 +143,4 @@ SCALE is a work in progress. If something gets in your way, please contact us.
 There are multiple ways to get in touch with us:
 
  - Join our [Discord](./contact/join-our-discord.md)
- - Send us an e-mail at [hello@spectralcompute.co.uk](mailto:hello@spectralcompute.co.uk)
+ - Send us an e-mail at [hello@spectralcompute.com](mailto:hello@spectralcompute.com)

--- a/docs/contact/join-our-discord.md
+++ b/docs/contact/join-our-discord.md
@@ -1,8 +1,8 @@
 # Join our Discord
 
-The success of SCALE very much depends on the developer community supporting it. We invite anyone curious about our technology to join our [Discord server](https://discord.gg/KNpgGbTc38) and follow our journey.
+The success of SCALE very much depends on the developer community supporting it. We invite anyone curious about our technology to join our [Discord server](https://scale-lang.com/s/discord?utm_source=docs&utm_medium=internal) and follow our journey.
 
-On our [Discord](https://discord.gg/KNpgGbTc38), we aim to:
+On our [Discord](https://scale-lang.com/s/discord?utm_source=docs&utm_medium=internal), we aim to:
 
 - Inform about [upcoming SCALE releases](https://docs.scale-lang.com/stable/manual/CHANGELOG/)
 - Share latest our [SCALE blog posts](https://scale-lang.com/posts)

--- a/docs/contact/report-a-bug.md
+++ b/docs/contact/report-a-bug.md
@@ -5,7 +5,7 @@ into problems, contact us by:
 
 - Joining our [Discord](./join-our-discord.md)
 - Creating [a ticket](https://github.com/spectral-compute/scale-validation/issues)
-- Sending us an e-mail at [hello@spectralcompute.co.uk](mailto:hello@spectralcompute.co.uk)
+- Sending us an e-mail at [hello@spectralcompute.com](mailto:hello@spectralcompute.com)
 
 The remainder of this page provides information about how to make your
 report as helpful as possible.

--- a/docs/contact/report-a-bug.md
+++ b/docs/contact/report-a-bug.md
@@ -3,7 +3,7 @@
 SCALE is still in active development, so you may encounter bugs. If you run
 into problems, contact us by:
 
-- Joining our [Discord](https://discord.gg/KNpgGbTc38)
+- Joining our [Discord](./join-our-discord.md)
 - Creating [a ticket](https://github.com/spectral-compute/scale-validation/issues)
 - Sending us an e-mail at [hello@spectralcompute.co.uk](mailto:hello@spectralcompute.co.uk)
 

--- a/docs/notices.md
+++ b/docs/notices.md
@@ -327,7 +327,7 @@ Some libcudacxx components not shipped with this distribution are covered by
 the below license. Each source file indicates which license it is under.
 
 If you find a file in our distribution with the following license,
-please let us know at legal@spectralcompute.co.uk immediately.
+please let us know at legal@spectralcompute.com immediately.
 ==============================================================================
 
 NVIDIA SOFTWARE LICENSE

--- a/docs/use_of_trademarks.md
+++ b/docs/use_of_trademarks.md
@@ -6,4 +6,4 @@ All uses of trademarks on this website are purely for nominative and/or descript
  - AMD ROCm is a registered trademark of Advanced Micro Devices, Inc.
  - SCALE is a registered trademark of Spectral Compute Ltd.
 
-Please contact us at [legal@spectralcompute.co.uk](mailto:legal@spectralcompute.co.uk) for any inquiries or corrections regarding our use of trademarks.
+Please contact us at [legal@spectralcompute.com](mailto:legal@spectralcompute.com) for any inquiries or corrections regarding our use of trademarks.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -99,7 +99,7 @@ extra:
     - icon: fontawesome/brands/linkedin
       link: https://www.linkedin.com/company/spectral-compute
     - icon: fontawesome/brands/discord
-      link: https://discord.gg/KNpgGbTc38
+      link: https://scale-lang.com/s/discord?utm_source=docs&utm_medium=internal
 
 copyright: Copyright &copy; 2026 <a href="https://www.spectralcompute.co.uk">Spectral Compute Ltd</a>
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,7 +101,7 @@ extra:
     - icon: fontawesome/brands/discord
       link: https://scale-lang.com/s/discord?utm_source=docs&utm_medium=internal
 
-copyright: Copyright &copy; 2026 <a href="https://www.spectralcompute.co.uk">Spectral Compute Ltd</a>
+copyright: Copyright &copy; 2026 <a href="https://spectralcompute.com">Spectral Compute Ltd</a>
 
 markdown_extensions:
   - toc:


### PR DESCRIPTION
## What

Gives the docs a single source of truth for the Discord invite, and moves the remaining contact details off the `.co.uk` domain.

- Every Discord mention now links to the **Join our Discord** contact page rather than pasting an invite URL.
- That page holds the one real URL, now the tracked `https://scale-lang.com/s/discord?utm_source=docs&utm_medium=internal`.
- The footer social icon points at the same tracked URL. (It stays an external link rather than an internal page, to match the GitHub/LinkedIn icons beside it.)
- `hello@spectralcompute.co.uk` → `hello@spectralcompute.com`, and `legal@spectralcompute.co.uk` → `.com`.
- Footer copyright link → `https://spectralcompute.com`.

## Why

The docs contained **three different Discord URLs** (`discord.gg/...`, `discord.com/invite/...`, and internal page links), none of the raw ones carrying tracking — so Discord clicks from the docs went unattributed.

## Notes

- The bare `spectralcompute.com` is used for the copyright link: both `www.` and the old `.co.uk` redirect there, so this avoids a redirect hop, and it matches the privacy-policy link already in the footer.
- The `legal@` line in `notices.md` is Spectral's own sentence, immediately above where the NVIDIA license text begins. No third-party license body was touched.

## Verification

- `mkdocs build --strict`: clean.
- No raw invite URL survives anywhere under `docs/`; the tracked URL exists in exactly one file.
- Confirmed the short link 301s to `discord.com/invite/KNpgGbTc38` — the same server as before.
- ⚠️ **Please confirm `legal@spectralcompute.com` is a live mailbox.** The domain redirects fine on the web, but mail routing is separate, and a bouncing legal/trademark contact would be a bad failure.
