### PR TITLE
Link scale-lang.com/brand-assets from the citation page

### DIFF
--- a/docs/citation.md
+++ b/docs/citation.md
@@ -20,10 +20,10 @@ This application is built with SCALE, a CUDA-compatible GPU programming
 toolkit by Spectral Compute (https://scale-lang.com).
 ```
 
-If you would like the SCALE logo for a slide deck or an "about" screen, get in
-touch on [Discord](./contact/join-our-discord.md) or at
-[hello@spectralcompute.com](mailto:hello@spectralcompute.com) and we will be
-happy to help.
+Our logos and usage guidelines are available at
+[scale-lang.com/brand-assets](https://scale-lang.com/brand-assets). If in
+doubt, reach out on [Discord](./contact/join-our-discord.md) or at
+[hello@spectralcompute.com](mailto:hello@spectralcompute.com).
 
 ## In Publications
 


### PR DESCRIPTION
⚠️ **Do not merge until the brand assets page ships at https://scale-lang.com/brand-assets** (in progress on the website side).

Replaces the "get in touch for the logo" sentence with a link to the brand assets page, keeping Discord/email as the fallback for doubts.

Based on #18, so it targets that branch; retarget to master if #18 merges first.